### PR TITLE
category削除後のエラー解消

### DIFF
--- a/frontend/src/components/Items.jsx
+++ b/frontend/src/components/Items.jsx
@@ -33,13 +33,12 @@ export default function Items() {
             >
                 <div className="flex flex-col">
                   <div className="text-base">{template.title}</div>
-                  <span className="text-xs text-blue-600 my-1">{category.name}</span>
+                  <span className="text-xs text-blue-600 my-1">{category?.name}</span>
                 </div>
             </li>
           )
         })}
       </ul>
     </div>
-
   ) 
 }


### PR DESCRIPTION
fetchの中でset関数が処理し終わる前にレンダリングが終わってるから、存在しないcategoryを参照しようとしてる？
よく分かってないのでbatchingとやらを調べてみる