### PR TITLE
リロード後のhandleGetCurrentUserの条件式を修正

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,7 +21,7 @@ function App() {
     try {
       const res = await getCurrentUser();
 
-      if (res?.data.isLogin === true) {
+      if (res.status === 200) {
         setIsSignedIn(true);
       } else {
         console.log("no current user");

--- a/frontend/src/components/pages/SignIn.jsx
+++ b/frontend/src/components/pages/SignIn.jsx
@@ -24,7 +24,6 @@ export const SignIn = () => {
 
     try {
       const res = await signIn(params);
-      console.log(res)
       if (res.status === 200) {
         Cookies.set("_access_token", res.headers["access-token"]);
         Cookies.set("_client", res.headers["client"]);


### PR DESCRIPTION
余分と思ってAPI側のレスポンスから`render json: {data...}`を消して`head :ok`に変更していた。
=> Reactでis_loginを受け取れないのに条件式にis_loginを使用していて。signInフラグが立たなかった。