### PR TITLE
再リロード時ゲストフラグを維持

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,6 @@ export const AuthContext = createContext();
 function App() {
   const [loading, setLoading] = useState(true);
   const [isSignedIn, setIsSignedIn] = useState(false);
-  const [isGuest , setIsGuest] = useState(false);
 
   const handleGetCurrentUser = async () => {
     try {
@@ -56,8 +55,6 @@ function App() {
         setLoading,
         isSignedIn,
         setIsSignedIn,
-        isGuest,
-        setIsGuest,
       }}
     >
         <BrowserRouter>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -3,10 +3,11 @@ import { useContext } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { AuthContext } from "../App"
 import { signOut } from "../api/auth";
+import Cookies from "js-cookie";
 
 export default function Header() {
-  const { isSignedIn, isGuest } = useContext(AuthContext);
-
+  const { isSignedIn } = useContext(AuthContext);
+  const isGuest = Cookies.get("_is_guest");
   const navigate = useNavigate();
 
   const handleSignOutClick = async() => {

--- a/frontend/src/components/pages/Home.jsx
+++ b/frontend/src/components/pages/Home.jsx
@@ -8,7 +8,7 @@ import Cookies from "js-cookie";
 
 
 export default function Home() {
-  const { setIsSignedIn, setIsGuest } = useContext(AuthContext);
+  const { setIsSignedIn } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const handleGuestLogin = async(e) => {
@@ -17,9 +17,9 @@ export default function Home() {
     Cookies.set("_access_token", res.data.token["accessToken"]);
     Cookies.set("_client", res.data.token["client"]);
     Cookies.set("_uid", res.data.token["uid"]);
+    Cookies.set("_is_guest", "true");
 
     setIsSignedIn(true);
-    setIsGuest(true);
     navigate("/template");
   }
 

--- a/frontend/src/components/pages/SignIn.jsx
+++ b/frontend/src/components/pages/SignIn.jsx
@@ -28,6 +28,7 @@ export const SignIn = () => {
         Cookies.set("_access_token", res.headers["access-token"]);
         Cookies.set("_client", res.headers["client"]);
         Cookies.set("_uid", res.headers["uid"]);
+        Cookies.remove("_is_guest");
 
         setIsSignedIn(true);
         navigate("/template");

--- a/frontend/src/components/pages/SignUp.jsx
+++ b/frontend/src/components/pages/SignUp.jsx
@@ -30,6 +30,7 @@ export const SignUp = () => {
       Cookies.set("_access_token", res.data.token["accessToken"]);
       Cookies.set("_client", res.data.token["client"]);
       Cookies.set("_uid", res.data.token["uid"]);
+      Cookies.remove("_is_guest");
 
       setIsSignedIn(true);
       navigate("/template");


### PR DESCRIPTION
isGuestをuseState => Cookie管理に変更。

useStateだとリロード時に初期値に変更されてしまうため。