### PR TITLE
category消去後のエラー解消

### DIFF
--- a/frontend/src/components/template/Sidebar/ItemBar.jsx
+++ b/frontend/src/components/template/Sidebar/ItemBar.jsx
@@ -7,22 +7,20 @@ import Item from "./Item";
 
 export default function ItemBar() {
   const { templates, categories, selectedCategory } = useContext(TemplateContext);
-  const [filteredTemplates, setFilteredTemplates] = useState(templates);
 
-  useEffect(() => {
+  const filteredTemplates =  () => {
     if (selectedCategory === null) {
-      setFilteredTemplates(templates);
+      return templates;
     } else {
-      setFilteredTemplates(templates
-                          .filter(template => template.category_id === selectedCategory.id));
+      return templates.filter(template => template.category_id === selectedCategory.id);
     }
-  }, [templates, selectedCategory]);
+  }
 
   return (
     <div className="max-h-1/3 px-4 py-2">
       <h3 className="text-xs font-semibold text-gray-500">テンプレート一覧</h3>
       <ul className="mt-2 space-y-1">
-        {filteredTemplates.map((template) => {
+        {filteredTemplates().map((template) => {
           const category = categories.find((category) => category.id === template.category_id)
           return <Item key={template.id} template={template} categoryName={category.name} />;
         })}


### PR DESCRIPTION
#### useEffext使用時
- filteredTemplatesはuseStateによって初期化されない
   - 既にItemBarはマウントされており、再レンダリング時は初期化されない
- useEffectが発火するタイミング前にJSXをブラウザに返す
=> 古いfilteredTemplatesがそのまま使われてcategory.nameのところでcategoryがnullの為エラー発生。

#### 対処
> useEffectは、コンポーネントを外部システムと同期させるためのReactフックです。
- useEffectは適切でないので削除
- フィルターされたテンプレートをreturnする関数に変更