### PR TITLE
アカウント作成時、同一Emailのアカウントがあった際にエラーメッセージを表示

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
   
   mount_devise_token_auth_for 'User', at: 'api/v1/auth', controllers: {
+    registrations: "api/v1/auth/registrations",
     omniauth_callbacks: "api/v1/auth/omniauth_callbacks"
   }
 

--- a/frontend/src/components/pages/SignUp.jsx
+++ b/frontend/src/components/pages/SignUp.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { signUp } from "../../api/auth";
 import Cookies from "js-cookie";
@@ -9,11 +9,15 @@ import GoogleLogin from "../oauth_button/GoogleLogin";
 
 
 export const SignUp = () => {
-  const { register, handleSubmit, formState: { errors } } = useForm({mode: "onChange"});
+  const { register, handleSubmit, watch, trigger, formState: { errors } } = useForm({mode: "onChange"});
   const { setIsSignedIn } = useContext(AuthContext);
   const navigate = useNavigate();
 
   const [isError, setIsError] = useState(false);
+  const password = watch("password");
+  useEffect(() => {
+    trigger("passwordConfirmation");
+  }, [password]);
 
 
   const onSubmit = async (data) => {
@@ -85,6 +89,7 @@ export const SignUp = () => {
           {...register("passwordConfirmation", {
             required: "確認用パスワードは必須です。", 
             minLength: {value: 6, message: "パスワードは6文字以上で入力してください。"},
+            validate: (value) => value === password || "パスワードが一致しません。"
           })}
         />
         <p className="text-red-400">{errors?.passwordConfirmation?.message}</p>

--- a/frontend/src/components/pages/SignUp.jsx
+++ b/frontend/src/components/pages/SignUp.jsx
@@ -33,7 +33,7 @@ export const SignUp = () => {
       navigate("/template");
     } catch (e) {
       if(e.status === 422) {
-        setErrorMessage("既にユーザーが存在しています");
+        setErrorMessage("既にユーザーが存在しています。別の方法でお試しください。");
       } else {
         setErrorMessage("ユーザー作成に失敗しました。")
       }

--- a/frontend/src/components/pages/SignUp.jsx
+++ b/frontend/src/components/pages/SignUp.jsx
@@ -16,8 +16,11 @@ export const SignUp = () => {
   const [ errorMessage, setErrorMessage ] = useState("");
 
   const password = watch("password");
+  const passwordConfirmation = watch("passwordConfirmation");
   useEffect(() => {
-    trigger("passwordConfirmation");
+    if(passwordConfirmation){
+      trigger("passwordConfirmation")
+    }
   }, [password]);
 
 

--- a/frontend/src/components/pages/SignUp.jsx
+++ b/frontend/src/components/pages/SignUp.jsx
@@ -13,7 +13,8 @@ export const SignUp = () => {
   const { setIsSignedIn } = useContext(AuthContext);
   const navigate = useNavigate();
 
-  const [isError, setIsError] = useState(false);
+  const [ errorMessage, setErrorMessage ] = useState("");
+
   const password = watch("password");
   useEffect(() => {
     trigger("passwordConfirmation");
@@ -22,14 +23,18 @@ export const SignUp = () => {
 
   const onSubmit = async (data) => {
     try {
-      const res = await signUp(data);
-      Cookies.remove("_is_guest");
+      await signUp(data);
 
+      Cookies.remove("_is_guest");
       setIsSignedIn(true);
       navigate("/template");
     } catch (e) {
+      if(e.status === 422) {
+        setErrorMessage("既にユーザーが存在しています");
+      } else {
+        setErrorMessage("ユーザー作成に失敗しました。")
+      }
       console.log("Error response:", e); 
-      setIsError(true);
     }
   };
 
@@ -44,12 +49,12 @@ export const SignUp = () => {
           <GoogleLogin />
         </div>
 
-        <div class="w-full">
-          <div class="divider">または</div>
+        <div className="w-full">
+          <div className="divider">または</div>
         </div>
 
         {/* モーダルに変更予定 */}
-        {isError && <p className="text-red-400 mb-4">入力が間違っています。</p>}
+        {errorMessage && <p className="text-red-400 mb-4">{errorMessage}</p>}
 
 
         <label className="label" htmlFor="email">メールアドレス</label>


### PR DESCRIPTION
## 概要

DeviseおよびOmniauthによるユーザー登録時、既に同じemailのユーザーが存在する場合にDB側でユニーク制約エラーが発生し、クライアントにRailsのエラー画面が表示される状態になっていました。

今回の修正により、登録前に同じemailのアカウントをチェックし、存在している場合には処理を中断、エラーメッセージを表示するよう変更しました。

## 内容

- `RegistrationsController`に`before_action :validate_email_uniqueness`を追加
- `OmniauthCallbacksController`の`omniauth_success`に`validate_email_uniquenessメソッド`を追加し、存在する場合はログイン画面にリダイレクトするよう修正
   - リダイレクト時クエリパラメータに`error=422`を追加し、クライアントで読み取ることでエラーメッセージを表示
