### PR TITLE
Develop

### DIFF
--- a/backend/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/backend/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -41,7 +41,8 @@ class Api::V1::Auth::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCall
   end
 
   def validate_email_uniqueness
-    user = User.find_by(email: auth_hash['info']['email'])
+    user = User.where(email: auth_hash['info']['email'])
+               .where.not(provider: auth_hash['provider'])
     
     redirect_to "http://localhost:5173/signin?error=422", allow_other_host: true if user.present?
   end

--- a/backend/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  before_action :validate_email_uniqueness, only: :create
+
+  protected
+
+  def render_data_or_redirect(message, data, user_data = {})
+    if ['inAppBrowser', 'newWindow'].include?(omniauth_window_type)
+      render_data(message, user_data.merge(data))
+    elsif auth_origin_url
+      redirect_to DeviseTokenAuth::Url.generate(auth_origin_url, data.merge(blank: true).merge(redirect_options)), allow_other_host: true
+    else
+      fallback_render data[:error] || 'An error occurred'
+    end
+  end
+
+  def validate_email_uniqueness
+    user = User.find_by(email: sign_up_params[:email])
+
+    render_error(:unprocessable_entity, "既にユーザーが存在しています", status: 'error') if user.present?
+  end
+  
+end

--- a/frontend/src/components/pages/SignIn.jsx
+++ b/frontend/src/components/pages/SignIn.jsx
@@ -22,7 +22,8 @@ export const SignIn = () => {
 
       setIsSignedIn(true);
       navigate("/template");
-      } catch (e) {
+    } catch (e) {
+      setErrorMessage("メールアドレスまたはパスワードが間違っています。");
       console.log("Error response:", e); 
     }
   }
@@ -34,8 +35,6 @@ export const SignIn = () => {
     
     if(error === "422") {
       setErrorMessage("既にユーザーが存在しています。別の方法でお試しください。");
-    } else {
-      setErrorMessage("メールアドレスまたはパスワードが間違っています。");
     }
   
     searchParams.delete("error");
@@ -55,7 +54,7 @@ export const SignIn = () => {
           </div>
 
           <div className="w-full">
-            <div classNam="divider">または</div>
+            <div className="divider">または</div>
           </div>
 
           {errorMessage && <p className="text-red-400 mb-4">{errorMessage}</p>}

--- a/frontend/src/components/pages/SignIn.jsx
+++ b/frontend/src/components/pages/SignIn.jsx
@@ -48,53 +48,55 @@ export const SignIn = () => {
         <h2 className="text-xl font-semibold">ログイン</h2>
       </div>
 
-      <fieldset className="fieldset rounded-box w-sm p-6 mt-10 shadow mx-auto">
-        <div className="my-5 flex-col">
-          <GoogleLogin />
-        </div>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <fieldset className="fieldset rounded-box w-sm p-6 mt-10 shadow mx-auto">
+          <div className="my-5 flex-col">
+            <GoogleLogin />
+          </div>
 
-        <div class="w-full">
-          <div class="divider">または</div>
-        </div>
+          <div className="w-full">
+            <div classNam="divider">または</div>
+          </div>
 
-        {errorMessage && <p className="text-red-400 mb-4">{errorMessage}</p>}
+          {errorMessage && <p className="text-red-400 mb-4">{errorMessage}</p>}
 
-        <label className="label" htmlFor="email">メールアドレス</label>
-        <input
-            type="email"
-            id="email"
-            className="input w-sm mb-1"
-            {...register("email", {
-              required: "メールアドレスは必須です。",
-              pattern: {value: /^[^@\s]+@[^@\s]+\.[^@\s]{2,}$/, message: "メールアドレスの形式が違います。"},
-            })}
-          />
-          <p className="text-red-400">{errors?.email?.message}</p>
+          <label className="label" htmlFor="email">メールアドレス</label>
+          <input
+              type="email"
+              id="email"
+              className="input w-sm mb-1"
+              {...register("email", {
+                required: "メールアドレスは必須です。",
+                pattern: {value: /^[^@\s]+@[^@\s]+\.[^@\s]{2,}$/, message: "メールアドレスの形式が違います。"},
+              })}
+            />
+            <p className="text-red-400">{errors?.email?.message}</p>
 
-        <label className="label" htmlFor="password">パスワード</label>
-        <input
-            type="password"
-            id="password"
-            className="input w-sm mb-1"
-            {...register("password", {
-              required: "パスワードは必須です。", 
-              minLength: {value: 6, message: "パスワードは6文字以上で入力してください。"},
-            })}
-          />
-          <p className="text-red-400">{errors?.password?.message}</p>
+          <label className="label" htmlFor="password">パスワード</label>
+          <input
+              type="password"
+              id="password"
+              className="input w-sm mb-1"
+              {...register("password", {
+                required: "パスワードは必須です。", 
+                minLength: {value: 6, message: "パスワードは6文字以上で入力してください。"},
+              })}
+            />
+            <p className="text-red-400">{errors?.password?.message}</p>
 
-        <Button type="submit" className="btn-primary mt-4" onClick={handleSubmit(onSubmit)}>
-          ログイン
-        </Button>
+          <Button type="submit" className="btn-primary mt-4">
+            ログイン
+          </Button>
 
-        <p className="text-center mt-5">
-          新規登録は<span className="text-blue-600"><Link to="/signup">こちら</Link></span>
-        </p>
+          <p className="text-center mt-5">
+            新規登録は<span className="text-blue-600"><Link to="/signup">こちら</Link></span>
+          </p>
 
-        <div className="mt-3">
-          <Link to="/" className="text-blue-600">ホームページに戻る</Link>
-        </div>
-      </fieldset>
+          <div className="mt-3">
+            <Link to="/" className="text-blue-600">ホームページに戻る</Link>
+          </div>
+        </fieldset>
+      </form>
     </div>
   );
 };


### PR DESCRIPTION
## 概要
- 細々とした修正
-  一度「既にユーザーが存在しています。」を表示させた後、他のエラーメッセージが表示されない
- 一度Google認証を実施したアカウントで再びGoogle認証によるログインが出来ない

## 対応
- エラーメッセージ
   - クエリパラメーターはアカウントが重複している場合のみなので、useEffect内で条件分岐せずcatchの方で表示するようにした。
- Googleログイン
   - `validate_email_uniqueness`内で重複するユーザーを探す条件がemailのみでGoogle認証のユーザーも当てはまる状態になっていた。
   - `where.not(provider: auth_hash['provider'])`を追加して同じプロバイダのアカウントは条件から除外するようにした。