### PR TITLE
Google認証失敗時、リダイレクト先を環境ごとに変更

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -28,6 +28,8 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem "rack-cors"
 
+gem 'dotenv-rails'
+
 gem "devise"
 
 gem "devise_token_auth"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
       bcrypt (~> 3.0)
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 8.1)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
     faraday (2.13.1)
@@ -335,6 +339,7 @@ DEPENDENCIES
   debug
   devise
   devise_token_auth
+  dotenv-rails
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg

--- a/backend/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/backend/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::Auth::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCall
     user = User.where(email: auth_hash['info']['email'])
                .where.not(provider: auth_hash['provider'])
     
-    redirect_to "http://localhost:5173/signin?error=422", allow_other_host: true if user.present?
+    redirect_to "#{ENV['FRONTEND_URL']}/signin?error=422", allow_other_host: true if user.present?
   end
 
 end


### PR DESCRIPTION
## 概要
`redirect_to "http://localhost:5173/signin?error=422", allow_other_host: true if user.present?`
同一Emailが存在していた時のレンダリング先が開発環境固定だったため、環境変数に修正