### PR TITLE
ゲストアカウントを定期的に削除

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM ruby:3.1.4
 
-RUN apt-get update -qq && apt-get install -y build-essential ca-certificates gnupg nodejs vim
+RUN apt-get update -qq && apt-get install -y build-essential ca-certificates gnupg nodejs vim cron
 
 RUN mkdir /backend
 WORKDIR /backend

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -38,6 +38,8 @@ gem 'omniauth-google-oauth2'
 
 gem "omniauth-rails_csrf_protection"
 
+gem 'whenever', require: false
+
 
 group :development, :test do
   gem "sqlite3", ">= 1.4"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     brakeman (7.0.2)
       racc
     builder (3.3.0)
+    chronic (0.10.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -319,6 +320,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -349,6 +352,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   sqlite3 (>= 1.4)
   tzinfo-data
+  whenever
 
 BUNDLED WITH
    2.5.9

--- a/backend/app/controllers/api/v1/guest_sessions_controller.rb
+++ b/backend/app/controllers/api/v1/guest_sessions_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::GuestSessionsController < ApplicationController
       email: guest_email,
       password: SecureRandom.hex(10),
       uid: guest_email,
-      provider: "email"
+      provider: "guest"
     )
 
     @token = @resource.create_token

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
   
   include DeviseTokenAuth::Concerns::User
 
-  has_many :templates
-  has_many :categories
+  has_many :templates, dependent: :destroy
+  has_many :categories, dependent: :destroy
 end

--- a/backend/config/schedule.rb
+++ b/backend/config/schedule.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+rails_env = ENV['RAILS_ENV'] || :development
+set :environment, rails_env
+set :output, "#{Rails.root}/log/cron.log"
+
+every 1.day, at: '2:00 am' do
+  rake "guest:delete_guest_accounts"
+end

--- a/backend/lib/tasks/guest.rake
+++ b/backend/lib/tasks/guest.rake
@@ -1,0 +1,13 @@
+namespace :guest do
+  desc "ゲストアカウント定期削除"
+  task delete_guest_accounts: :environment do
+    guest_users = User.where(provider: "guest")
+    if guest_users.present?
+      guest_users.destroy_all
+      puts "ゲストユーザーを削除しました。"
+    else
+      puts "現在ゲストユーザーはいません。"
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要
railsのgem"whenever"を使用してゲストアカウントを午前2時に削除するよう設定した。

## その他内容
- cronを使用するため、Dockerイメージにcronをインストールするよう追加
- ゲストアカウントのproviderを"guest"にするよう設定
- user削除時、ゲスト用のテンプレートとカテゴリーが残ってしまったためUser.rbにdependent: :destroyを追加